### PR TITLE
How did it even work and pass the tests?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ const prepareConstraintDirective = (validationCallback, errorMessageCallback) =>
         )
 
         const errors = validate(this.args)
-        if (errors) throw new Error(errors)
+        if (errors && errors.length > 0) throw new Error(errors)
 
         return originalResolver.apply(this, resolveArgs)
       }


### PR DESCRIPTION
If argument passes the constraint validation, `errors` is an empty array.