### PR TITLE
[WIP] Add support of nested logical combinators (fix #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Example GraphQL Schema:
 ```graphql
 type Query {
   createUser (
-    name: String! @constraint(minLength: 5, maxLength: 40)
-    emailAddr: String @constraint(format: "email")
-    otherEmailAddr: String @constraint(format: "email", differsFrom: "emailAddr")
-    age: Int @constraint(min: 18)
+    name: String! @constraint(where: {minLength: 5, maxLength: 40})
+    emailAddr: String @constraint(where: {format: "email"})
+    otherEmailAddr: String @constraint(where: {format: "email", differsFrom: "emailAddr"})
+    age: Int @constraint(where: {min: 18})
+    bio: String @constraint(where: {OR: [{contains: "foo"}, {contains: "bar"}]})
   ): User
 }
 ```
@@ -53,7 +54,12 @@ const server = new GraphQLServer({
 You may need to declare the directive in the schema:
 
 ```graphql
-directive @constraint(
+directive @constraint(where: constraintsWhereInput!) on ARGUMENT_DEFINITION
+
+input constraintsWhereInput {
+  AND: [constraintsWhereInput!]
+  OR: [constraintsWhereInput!]
+  NOT: [constraintsWhereInput!]
   minLength: Int
   maxLength: Int
   startsWith: String
@@ -68,7 +74,7 @@ directive @constraint(
   exclusiveMin: Float
   exclusiveMax: Float
   notEqual: Float
-) on ARGUMENT_DEFINITION
+}
 ```
 
 ## API

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,9 @@ const {
   GraphQLFloat,
   GraphQLString,
   GraphQLSchema,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
   printSchema
 } = require('graphql')
 
@@ -30,11 +33,13 @@ const prepareConstraintDirective = (validationCallback, errorMessageCallback) =>
     }
 
     static getDirectiveDeclaration (directiveName, schema) {
-      return new GraphQLDirective({
-        name: directiveName,
-        locations: [DirectiveLocation.ARGUMENT_DEFINITION],
-        args: {
+      const constraintsWhereInput = new GraphQLNonNull(new GraphQLInputObjectType({
+        name: 'constraintsWhereInput',
+        fields: () => ({
           /* Strings */
+          AND: { type: new GraphQLList(constraintsWhereInput) },
+          OR: { type: new GraphQLList(constraintsWhereInput) },
+          NOT: { type: new GraphQLList(constraintsWhereInput) },
           minLength: { type: GraphQLInt },
           maxLength: { type: GraphQLInt },
           startsWith: { type: GraphQLString },
@@ -51,6 +56,14 @@ const prepareConstraintDirective = (validationCallback, errorMessageCallback) =>
           exclusiveMin: { type: GraphQLFloat },
           exclusiveMax: { type: GraphQLFloat },
           notEqual: { type: GraphQLFloat }
+        })
+      }));
+
+      return new GraphQLDirective({
+        name: directiveName,
+        locations: [DirectiveLocation.ARGUMENT_DEFINITION],
+        args: {
+          where: { type:  constraintsWhereInput }
         }
       })
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,8 @@ const compose = (...fnlist) => data =>
   [...fnlist, data].reduceRight((prev, fn) => fn(prev))
 
 const mapObjIndexed = fn => obj => {
+  //FIXME: sure, there is a better way to do this
+  obj = obj['where'];
   const acc = {}
   Object.keys(obj).forEach(key => (acc[key] = fn(obj[key], key, obj)))
   return acc

--- a/src/validators.js
+++ b/src/validators.js
@@ -49,7 +49,11 @@ const numericValidators = {
   max: max => x => x <= max,
   exclusiveMin: min => x => x > min,
   exclusiveMax: max => x => x < max,
-  notEqual: neq => x => x !== neq
+  notEqual: neq => x => x !== neq,
+  //TODO: implement the following validators
+  //OR: ,
+  //AND: ,
+  //NOT:
 }
 
 const defaultErrorMessageCallback = ({ argName, cName, cVal, data }) =>

--- a/src/validators.js
+++ b/src/validators.js
@@ -49,11 +49,14 @@ const numericValidators = {
   max: max => x => x <= max,
   exclusiveMin: min => x => x > min,
   exclusiveMax: max => x => x < max,
-  notEqual: neq => x => x !== neq,
-  //TODO: implement the following validators
+  notEqual: neq => x => x !== neq
+}
+
+//TODO: implement it
+const logicalValidators = {
   //OR: ,
   //AND: ,
-  //NOT:
+  //NOT: 
 }
 
 const defaultErrorMessageCallback = ({ argName, cName, cVal, data }) =>
@@ -62,6 +65,7 @@ const defaultErrorMessageCallback = ({ argName, cName, cVal, data }) =>
 const defaultValidators = {
   ...formatValidator(format2fun),
   ...numericValidators,
+  ...logicalValidators,
   ...stringValidators
 }
 
@@ -77,6 +81,7 @@ module.exports = {
   createValidationCallback,
   stringValidators,
   numericValidators,
+  logicalValidators,
   formatValidator,
   format2fun
 }


### PR DESCRIPTION
This pull request adds support of nested logical combinators `OR`, `AND` and `NOT` to create an arbitrary logical combination of validators:

```graphql
type Query {
  createUser (
    id: ID!
    name: String! @constraint(where: {minLength: 5, maxLength: 40})
    bio: String @constraint(
      where: {
        OR: [{
          AND: [{
            startsWith: "foo"
          }, {
            endsWith: "bar"
          }]
        }, {
          contains: "baz"
        }]
      }
    )
  ): User
}
```

The syntax is the same as used in Prisma: https://www.prisma.io/docs/prisma-graphql-api/reference/queries-qwe1/#combining-multiple-filters.